### PR TITLE
Use playable area for map size

### DIFF
--- a/lua/ui/game/score.lua
+++ b/lua/ui/game/score.lua
@@ -239,6 +239,8 @@ ShareDescriptionLookup["TransferToKiller"] = "lobui_0763"
 ShareDescriptionLookup["Defectors"] = "lobui_0767"
 ShareDescriptionLookup["CivilianDeserter"] = "lobui_0765"
 
+local mapSizeUI = false
+
 function SetupPlayerLines()
     local function CreateArmyLine(data, armyIndex)
         local group = Group(controls.bgStretch)
@@ -448,8 +450,8 @@ function SetupPlayerLines()
         previous = group.ShareConditions
         previous = AddDash()
 
-        -- ui for map name
-        group.Size = UIUtil.CreateText(group, tostring(data.Size.Width) .. "x" .. tostring(data.Size.Height), 10, UIUtil.bodyFont)
+        -- ui for map size
+        group.Size = UIUtil.CreateText(group, data.SizeText, 10, UIUtil.bodyFont)
         LayoutHelpers.RightOf(group.Size, previous)
         LayoutHelpers.AtVerticalCenterIn(group.Size, group)
         group.Size:SetColor('ffffffff')
@@ -509,7 +511,17 @@ function SetupPlayerLines()
     mapData.ShareConditionsDescription = mapData.ShareConditionsDescription .. "\r\n\r\n" .. LOC("<LOC info_game_settings_dialog>Other game settings can be found in the map information dialog (F12).")
 
     -- add size to the score board
-    mapData.Size = { Width = math.floor(sessionInfo.size[1] / 51.2), Height = math.floor(sessionInfo.size[2] / 51.2) }
+    local mapWidth = sessionInfo.size[1]
+    local mapHeight = sessionInfo.size[2]
+    local areaData = Sync.NewPlayableArea
+    if areaData then
+        -- use the playable area if provided by the map
+        mapWidth = areaData[3] - areaData[1]
+        mapHeight = areaData[4] - areaData[2]
+    end
+    mapData.SizeText = MapSizeText(mapWidth, mapHeight)
+    sessionInfo.PlayableAreaWidth = mapWidth
+    sessionInfo.PlayableAreaHeight = mapHeight
 
     -- add map title / description to the scoreboard
     mapData.MapTitle = LOCF("<LOC gamesel_0002>%s", sessionInfo.name)
@@ -529,6 +541,7 @@ function SetupPlayerLines()
     -- construct UI elements
     local mapUI = CreateMapNameLine(mapData)
     controls.armyLines[index] = mapUI
+    mapSizeUI = mapUI.Size
 
     resModeSwitch.icon = UIUtil.CreateText(controls.armyGroup, '⃝', 13, 'Calibri')
     resModeSwitch.icon.Depth:Set(mapUI.Depth() + 1)
@@ -557,6 +570,13 @@ function SetupPlayerLines()
     local bodyText = 'I - '..LOC('<LOC tooltipui0714>Income')..'\n B - '..
         LOC('<LOC tooltipui0715>Balance')..'\n S - '..LOC('<LOC uvd_0006>Storage')
     Tooltip.AddControlTooltip(resModeSwitch.icon, {text = '', body = bodyText}, 1)
+end
+
+function MapSizeText(width, height)
+    -- round half down; this won't let fractional map sizes (e.g. from the map gen) make it needlessly long
+    local widthKm = math.ceil(width / 51.2 - 0.5)
+    local heightKm = math.ceil(height / 51.2 - 0.5)
+    return tostring(widthKm) .. "x" .. tostring(heightKm)
 end
 
 function DisplayResources(resources, line, mode)
@@ -708,6 +728,20 @@ function _OnBeat()
             end
         end
         prevArmy = curFA
+    end
+    
+    -- this will be needed only for very few maps that change the playable area after initialization
+    local areaData = Sync.NewPlayableArea
+    if areaData then
+        local width = areaData[3] - areaData[1]
+        local height = areaData[4] - areaData[2]
+        if width ~= sessionInfo.PlayableAreaWidth or height ~= sessionInfo.PlayableAreaHeight then
+            sessionInfo.PlayableAreaWidth = width
+            sessionInfo.PlayableAreaHeight = height
+            if mapSizeUI then
+                mapSizeUI:SetText(MapSizeText(width, height))
+            end
+        end
     end
 end
 


### PR DESCRIPTION
Change the map size in the score panel to reflect the current playable area instead of the raw map bounds

This branch is for bugfixes, general improvements, and new features. If your change is designed to alter balance, please make 
sure your changes are rebased onto [development/balance] (https://github.com/FAForever/fa/tree/development/balance), and target that branch with your PR.